### PR TITLE
Add interactive tutorial

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,9 +50,8 @@
       <div class="crest"></div>
       <div class="titles">
         <h1 class="page-title">Ethereal</h1>
-        <p class="page-sub">
-          Clique esquerdo: virar carta • Clique direito: selecionar 2 heróis
-        </p>
+        <button id="btnTutorial" class="tutorial-button">Tutorial</button>
+        <p class="page-sub">Use o botão Tutorial para aprender a jogar</p>
       </div>
     </header>
 
@@ -279,6 +278,12 @@
         </div>
       </div>
     </template>
+
+    <div id="tutorialOverlay" class="tutorial-overlay" aria-hidden="true">
+      <div id="tutorialPointer" class="tutorial-pointer">👇</div>
+      <div id="tutorialMessage" class="tutorial-message"></div>
+      <button id="tutorialNext" class="tutorial-next">Próximo</button>
+    </div>
 
     <div id="arena" class="arena-overlay">
       <div class="arena-bg"></div>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1097,3 +1097,76 @@
   position: relative;
   cursor: pointer;
 }
+
+/* Tutorial */
+.tutorial-button {
+  margin-left: 12px;
+  padding: 4px 12px;
+  font-size: 0.9rem;
+  background: var(--ui-bg1);
+  border: 2px solid var(--ui-border);
+  color: var(--ui-text);
+  border-radius: 8px;
+  cursor: pointer;
+  animation: pulseGlow 2s infinite;
+}
+
+@keyframes pulseGlow {
+  0% {
+    box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.8);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(255, 255, 255, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
+  }
+}
+
+.tutorial-overlay {
+  position: fixed;
+  inset: 0;
+  display: none;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 150;
+}
+.tutorial-overlay.show {
+  display: block;
+}
+.tutorial-pointer {
+  position: absolute;
+  font-size: 2rem;
+  color: #fff;
+  transform: translateX(-50%);
+}
+.tutorial-message {
+  position: absolute;
+  transform: translateX(-50%);
+  background: var(--ui-bg1);
+  color: var(--ui-text);
+  border: 2px solid var(--ui-border);
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-family: 'Cinzel', serif;
+  text-align: center;
+  max-width: 260px;
+}
+.tutorial-next {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--ui-bg1);
+  color: var(--ui-text);
+  border: 2px solid var(--ui-border);
+  border-radius: 8px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+.tutorial-highlight {
+  box-shadow:
+    0 0 0 3px rgba(255, 255, 255, 0.9),
+    0 0 8px 4px rgba(255, 255, 255, 0.6);
+  position: relative;
+  z-index: 160;
+}

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1333,5 +1333,73 @@ document.getElementById('btnClose').addEventListener('click', resetArena);
 document.getElementById('btnReset').addEventListener('click', resetAllLevels);
 window.addEventListener('resize', () => {
   if (arena.classList.contains('show')) positionBattleLog();
+  if (tutorialOverlay.classList.contains('show')) showTutorialStep();
 });
 document.addEventListener('DOMContentLoaded', loadHeroesData);
+
+// Tutorial
+const tutorialOverlay = document.getElementById('tutorialOverlay');
+const tutorialPointer = document.getElementById('tutorialPointer');
+const tutorialMessage = document.getElementById('tutorialMessage');
+const tutorialNext = document.getElementById('tutorialNext');
+
+const tutorialSteps = [
+  {
+    target: '#grid',
+    text: 'Use o clique esquerdo para virar as cartas',
+    arrow: '👇',
+  },
+  {
+    target: '#grid',
+    text: 'Use o clique direito para selecionar um herói',
+    arrow: '👇',
+  },
+  {
+    target: '#btnStart',
+    text: 'Após escolher 2 heróis, clique em Iniciar Combate',
+    arrow: '👇',
+  },
+];
+
+let tutorialIndex = 0;
+
+function highlightTarget(selector) {
+  document.querySelectorAll('.tutorial-highlight').forEach(el => {
+    el.classList.remove('tutorial-highlight');
+  });
+  const el = document.querySelector(selector);
+  if (!el) return;
+  el.classList.add('tutorial-highlight');
+  const rect = el.getBoundingClientRect();
+  const scrollY = window.scrollY || window.pageYOffset;
+  const scrollX = window.scrollX || window.pageXOffset;
+  tutorialPointer.style.top = `${rect.bottom + 10 + scrollY}px`;
+  tutorialPointer.style.left = `${rect.left + rect.width / 2 + scrollX}px`;
+  tutorialMessage.style.top = `${rect.bottom + 50 + scrollY}px`;
+  tutorialMessage.style.left = `${rect.left + rect.width / 2 + scrollX}px`;
+}
+
+function showTutorialStep() {
+  const step = tutorialSteps[tutorialIndex];
+  tutorialPointer.textContent = step.arrow;
+  tutorialMessage.textContent = step.text;
+  highlightTarget(step.target);
+}
+
+document.getElementById('btnTutorial').addEventListener('click', () => {
+  tutorialIndex = 0;
+  tutorialOverlay.classList.add('show');
+  showTutorialStep();
+});
+
+tutorialNext.addEventListener('click', () => {
+  tutorialIndex += 1;
+  if (tutorialIndex >= tutorialSteps.length) {
+    tutorialOverlay.classList.remove('show');
+    document.querySelectorAll('.tutorial-highlight').forEach(el => {
+      el.classList.remove('tutorial-highlight');
+    });
+  } else {
+    showTutorialStep();
+  }
+});


### PR DESCRIPTION
## Summary
- swap help button for pulsing Tutorial button
- include an interactive tutorial overlay with steps
- style Tutorial button, overlay and highlight effect
- implement JavaScript to position tutorial messages and advance steps

## Testing
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_6885cc8b76a0832b925d8ca1c887de02