### PR TITLE
Add event-driven tutorial

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,9 +50,7 @@
       <div class="crest"></div>
       <div class="titles">
         <h1 class="page-title">Ethereal</h1>
-        <p class="page-sub">
-          Clique esquerdo: virar carta • Clique direito: selecionar 2 heróis
-        </p>
+        <button id="btnTutorial" class="tutorial-button">Tutorial</button>
       </div>
     </header>
 
@@ -279,6 +277,10 @@
         </div>
       </div>
     </template>
+
+    <div id="tutorialOverlay" class="tutorial-overlay" aria-hidden="true">
+      <div id="tutorialMessage" class="tutorial-message"></div>
+    </div>
 
     <div id="arena" class="arena-overlay">
       <div class="arena-bg"></div>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -760,7 +760,7 @@
   position: absolute;
   bottom: 18px;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
   display: flex;
   gap: 12px;
   z-index: 8;
@@ -1096,4 +1096,64 @@
 .primary-button {
   position: relative;
   cursor: pointer;
+}
+
+/* Tutorial */
+.tutorial-button {
+  margin-left: 12px;
+  padding: 4px 12px;
+  font-size: 0.9rem;
+  background: var(--ui-bg1);
+  border: 2px solid var(--ui-border);
+  color: var(--ui-text);
+  border-radius: 8px;
+  cursor: pointer;
+  animation: pulseGlow 2s infinite;
+}
+
+@keyframes pulseGlow {
+  0% {
+    box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.8);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(255, 255, 255, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
+  }
+}
+
+.tutorial-overlay {
+  position: fixed;
+  inset: 0;
+  display: none;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 150;
+}
+.tutorial-overlay.show {
+  display: block;
+}
+.tutorial-message {
+  top: 50%;
+  left: 50%;
+  position: absolute;
+  transform: translate(-50%, -50%);
+  background: var(--ui-bg1);
+  color: var(--ui-text);
+  border: 2px solid var(--ui-border);
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-family: 'Cinzel', serif;
+  text-align: center;
+  max-width: 260px;
+}
+.tutorial-highlight {
+  box-shadow:
+    0 0 0 3px rgba(255, 255, 255, 0.9),
+    0 0 8px 4px rgba(255, 255, 255, 0.6);
+  position: relative;
+  z-index: 160;
+}
+.tutorial-pulse {
+  animation: pulseGlow 1.5s infinite;
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1335,3 +1335,52 @@ window.addEventListener('resize', () => {
   if (arena.classList.contains('show')) positionBattleLog();
 });
 document.addEventListener('DOMContentLoaded', loadHeroesData);
+
+// Tutorial
+const tutorialOverlay = document.getElementById('tutorialOverlay');
+const tutorialMessage = document.getElementById('tutorialMessage');
+let tutorialStage = 0;
+
+function startTutorial() {
+  tutorialStage = 0;
+  tutorialOverlay.classList.add('show');
+  tutorialMessage.textContent =
+    'Clique com o botão direito em um card para selecionar';
+  document.querySelectorAll('.card-container').forEach((el, idx) => {
+    el.classList.add('tutorial-highlight');
+    if (idx < 2) el.classList.add('tutorial-pulse');
+  });
+}
+
+function endTutorial() {
+  tutorialOverlay.classList.remove('show');
+  document.querySelectorAll('.tutorial-highlight').forEach(el => {
+    el.classList.remove('tutorial-highlight', 'tutorial-pulse');
+  });
+}
+
+document.getElementById('btnTutorial').addEventListener('click', startTutorial);
+
+grid.addEventListener('contextmenu', e => {
+  if (!tutorialOverlay.classList.contains('show')) return;
+  if (tutorialStage === 0) {
+    tutorialMessage.textContent =
+      'Agora clique com o esquerdo para virar o card';
+    tutorialStage = 1;
+  }
+});
+
+grid.addEventListener('click', () => {
+  if (!tutorialOverlay.classList.contains('show')) return;
+  if (tutorialStage === 1) {
+    tutorialMessage.textContent =
+      'Selecione dois heróis e clique em Iniciar Combate';
+    tutorialStage = 2;
+  }
+});
+
+btnStart.addEventListener('click', () => {
+  if (tutorialOverlay.classList.contains('show') && tutorialStage >= 2) {
+    endTutorial();
+  }
+});


### PR DESCRIPTION
## Summary
- remove instructional subtitle
- simplify tutorial overlay markup
- style centered tutorial message and pulsing highlight
- replace next-button flow with event-driven tutorial stages

## Testing
- `npm install`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_6885cc8b76a0832b925d8ca1c887de02